### PR TITLE
Added ability to send tokens via HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ accepts these credentials and calls `done` providing a user, as well as
       }
     ));
 
+#### Authenticate Requests
+
+Use `passport.authenticate('google-token')` to authenticate requests.
+
+    router.get('/auth/google/token', passport.authenticate('google-token'),
+     function(req, res) {
+      res.send(req.user);
+    });
+
+GET request need to have `access_token` and optionally the `refresh_token` in either the query string or set as a header.  If a POST is being preformed they can also be included in the body of the request.
+
 ## Credits
 
   - [Nicholas Penree](http://github.com/drudge)

--- a/lib/passport-google-token/strategy.js
+++ b/lib/passport-google-token/strategy.js
@@ -44,7 +44,7 @@ function GoogleTokenStrategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://accounts.google.com/o/oauth2/auth';
   options.tokenURL = options.tokenURL || 'https://accounts.google.com/o/oauth2/token';
-  
+
   OAuth2Strategy.call(this, options, verify);
   this.name = 'google-token';
 }
@@ -70,23 +70,23 @@ GoogleTokenStrategy.prototype.authenticate = function(req, options) {
     //       query parameters, and should be propagated to the application.
     return this.fail();
   }
-  
+
   if (!req.body) {
     return this.fail();
   }
-  
-  var accessToken = req.body.access_token || req.query.access_token;
-  var refreshToken = req.body.refresh_token || req.query.refresh_token;
-  
+
+  var accessToken = req.body.access_token || req.query.access_token || req.headers.access_token;
+  var refreshToken = req.body.refresh_token || req.query.refresh_token || req.headers.refresh_token;
+
   self._loadUserProfile(accessToken, function(err, profile) {
     if (err) { return self.fail(err); };
-    
+
     function verified(err, user, info) {
       if (err) { return self.error(err); }
       if (!user) { return self.fail(info); }
       self.success(user, info);
     }
-    
+
     if (self._passReqToCallback) {
       self._verify(req, accessToken, refreshToken, profile, verified);
     } else {
@@ -112,20 +112,20 @@ GoogleTokenStrategy.prototype.authenticate = function(req, options) {
 GoogleTokenStrategy.prototype.userProfile = function(accessToken, done) {
   this._oauth2.get('https://www.googleapis.com/oauth2/v1/userinfo', accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-    
+
     try {
       var json = JSON.parse(body);
-      
+
       var profile = { provider: 'google' };
       profile.id = json.id;
       profile.displayName = json.name;
       profile.name = { familyName: json.family_name,
                        givenName: json.given_name };
       profile.emails = [{ value: json.email }];
-      
+
       profile._raw = body;
       profile._json = json;
-      
+
       done(null, profile);
     } catch(e) {
       done(e);
@@ -168,5 +168,5 @@ GoogleTokenStrategy.prototype._loadUserProfile = function(accessToken, done) {
 
 /**
  * Expose `GoogleTokenStrategy`.
- */ 
+ */
 module.exports = GoogleTokenStrategy;


### PR DESCRIPTION
This makes GET requests easier to manage and mimics the behavior of the
similar [passport-facebook-token](https://github.com/drudge/passport-facebook-to
ken) project.
