### PR TITLE
fallback req.body without fail

### DIFF
--- a/lib/passport-google-token/strategy.js
+++ b/lib/passport-google-token/strategy.js
@@ -72,7 +72,7 @@ GoogleTokenStrategy.prototype.authenticate = function(req, options) {
   }
 
   if (!req.body) {
-    return this.fail();
+    req.body = {};
   }
 
   var accessToken = req.body.access_token || req.query.access_token || req.headers.access_token;


### PR DESCRIPTION
`req.body` in some cases is not defined, but the call is correct because the data is on `req.query`.
For that the call should not fail.
