### PR TITLE
Fix issue when users send token via query

### DIFF
--- a/lib/passport-google-token/strategy.js
+++ b/lib/passport-google-token/strategy.js
@@ -67,13 +67,14 @@ GoogleTokenStrategy.prototype.authenticate = function(req, options) {
 
   if (req.query && req.query.error) {
     // TODO: Error information pertaining to OAuth 2.0 flows is encoded in the
-    //       query parameters, and should be propagated to the application.
+    // query parameters, and should be propagated to the application.
     return this.fail();
   }
 
-  if (!req.body) {
-    return this.fail();
-  }
+  // assign default value to make sure next command can work well
+  req.body = req.body || {};
+  req.query = req.query || {};
+  req.headers = req.headers || {};
 
   var accessToken = req.body.access_token || req.query.access_token || req.headers.access_token;
   var refreshToken = req.body.refresh_token || req.query.refresh_token || req.headers.refresh_token;


### PR DESCRIPTION
Currently, If users send `access_token` via query of the request. They will get `unauthorized` message, this pull request will fix that.