### PR TITLE
Fixed Import statement in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ unobtrusively integrated into any application or framework that supports
 
 ## Usage
 
+#### Import Module
+
+const GoogleTokenStrategy = require("passport-google-token").Strategy;
+
 #### Configure Strategy
 
 The Google authentication strategy authenticates users using a Google

--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ unobtrusively integrated into any application or framework that supports
 ## Usage
 
 #### Import Module
+Right this statement to import the module.
 
-const GoogleTokenStrategy = require("passport-google-token").Strategy;
+    const GoogleTokenStrategy = require("passport-google-token").Strategy;
+
+
 
 #### Configure Strategy
 


### PR DESCRIPTION
Import was not defined in readme file and even in the Runkit file on npmjs.com , the import statement provided didn't work. So adding a little change in it for convenience of the developers.